### PR TITLE
Enable nodemon exec script, don't reload server upon lint errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ It will automatically ignore your node_modules folder and any files/folders that
   },
   "nodemonConfig": {
     watch: ["api/"],
-    ignore: ["api/scripts"]
+    ignore: ["api/scripts"],
+    // optional execute script, for example to use babel-node    
+    "exec": "babel-node api/start.js"
   },
   ...
 }


### PR DESCRIPTION
Referencing https://github.com/theoephraim/lint-fix-nodemon/issues/3

- This PR enables nodemon exec script, so lint-fix-nodemon can be run with for example babel-node
- It will stop nodemon upon lint errors
- Updated readme

Config needs to be changed like this:

```
  "nodemonConfig": {
    "watch": [
      "app/"
    ],
    // optional execute script, for example to use babel-node    
    "exec": "babel-node api/start.js"
  }
```